### PR TITLE
Add a secret parameter

### DIFF
--- a/lib/fluent/plugin/out_yo.rb
+++ b/lib/fluent/plugin/out_yo.rb
@@ -3,7 +3,7 @@ module Fluent
   class YoOutput < Fluent::Output
     Fluent::Plugin.register_output('yo', self)
 
-    config_param :api_key, :string, :default => nil
+    config_param :api_key, :string, :default => nil, :secret => true
 
     def initialize
       super


### PR DESCRIPTION
Fluentd 0.12.11 or later supports secret parameter feature.
By this feature, a parameter specified `:secret => true` will be concealed with xxxxxx in log as below:

``` log
  <match yo.**>
    type yo
    api_key xxxxxx
  </match>
</ROOT>
```

I hope this pull request helps you, thanks.
