### PR TITLE
Add test-unit 3.0 or later development dependency.

### DIFF
--- a/fluent-plugin-yo.gemspec
+++ b/fluent-plugin-yo.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "webmock"
+  spec.add_development_dependency "test-unit", ">= 3.0.0"
 end


### PR DESCRIPTION
Ruby 2.2 no loger exports 'test/unit'.
test-unit has compatible API against 'test/unit'.
Let's enjoy fluentd plugin development with Ruby 2.2!
